### PR TITLE
Disallow users from updating their own stuff

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -73,21 +73,15 @@ func Tag(db *gorm.DB) gin.HandlerFunc {
 func Update(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		data := c.MustGet("data").(models.User)
-		// Nobody can change UgKthid
 		data.UgKthid = ""
 
-		uid := c.MustGet("uid").(string)
 		admin := c.MustGet("admin").(bool)
 		if !admin {
-			// No admin? No change
-			data.Uid = ""
-		}
-
-		ldap.ExactUid(c.Param("uid"))
-		if uid != c.Param("uid") && !admin {
 			c.JSON(401, gin.H{"error": "Permission denied."})
 			return
 		}
+
+		ldap.ExactUid(c.Param("uid"))
 		var user models.User
 		db.Where(models.User{Uid: c.Param("uid")}).Assign(data).FirstOrCreate(&user)
 		c.JSON(200, user)


### PR DESCRIPTION
The frontend in zfinger doesn't even seem to provide the login token so updating one's year doesn't even work anymore. Apparently anyone can currently updates one's information (except ugkthid and kthid, but including tag & names), which I have been told should be possible.

With the recent addition, this also includes membership status, which people should definitely not be able to decide for one self.

Until those changes people's names were sometimes reset due to searches that hit kth:s ldap. That was apparently just a temporary thing since 2018 that I removed so now people can decide what their names and emails should be.